### PR TITLE
Integrate Prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,11 @@
+# Ignore documentation files
+*.md
+
+# Ignore build directories
+dist/
+build/
+node_modules/
+
+# Ignore test files
+__tests__/
+*.spec.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,11 @@
+{
+  "arrowParens": "avoid",
+  "jsxSingleQuote": true,
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all",
+  "plugins": ["prettier-plugin-tailwindcss"],
+  "tailwindConfig": "./front-end/tailwind.config.js"
+}

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -28,7 +28,9 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "format": "prettier --write '**/*.{js,jsx,ts,tsx,json,css,scss,md}'",
+    "format:check": "prettier --check '**/*.{js,jsx,ts,tsx,json,css,scss,md}'"
   },
   "eslintConfig": {
     "extends": [

--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "devDependencies": {
+    "prettier": "^3.3.3",
+    "prettier-plugin-tailwindcss": "^0.6.8"
+  }
+}


### PR DESCRIPTION
**Overview**: This pull request integrates Prettier into the project to enforce consistent code formatting across the front-end codebase. To format the code, run the following command in your terminal:

```bash
cd front-end
npm run format
```

**Key Changes**:

1. Prettier Configuration: 
* `Enabled` trailingComma for all applicable items.
* Set `tabWidth` to 2 spaces for indentation.
* Used `singleQuote` for strings and specified jsxSingleQuote for JSX files.
* Set `printWidth` to 100 characters.
* Configured `semi` to ensure semicolons are added at the end of statements.
* Integrated the `prettier-plugin-tailwindcss` to sort Tailwind CSS classes automatically.

2. Package Scripts:
* `format`: Runs Prettier to format files in the project.
* `format:check`: Checks the formatting without making changes.
