### PR TITLE
Restore MongoDB connection

### DIFF
--- a/back-end/src/app.js
+++ b/back-end/src/app.js
@@ -14,6 +14,8 @@ export const connectToDatabase = async () => {
     }
 };
 
+connectToDatabase();
+
 const app = express();
 
 app.use((req, res, next) => {


### PR DESCRIPTION
A previous commit refactored the MongoDB connection logic into a connectToDatabase function but forgot to invoke it